### PR TITLE
Gerar pacote deb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Byte-compiled / optimized / DLL files
+.idea
 go.sum
-moisapps
+build/package/moisapps/usr/local/bin/moisapps
+build/package/moisapps.deb

--- a/build/package/moisapps/DEBIAN/control
+++ b/build/package/moisapps/DEBIAN/control
@@ -1,0 +1,6 @@
+Package: moisapps
+Version: 1.0.0
+Architecture: amd64
+Maintainer: Community Edition
+Description: Moisapps is an automation for application creation and release
+ Moisapps is an automation for application creation and release

--- a/build/package/moisapps/DEBIAN/preinst
+++ b/build/package/moisapps/DEBIAN/preinst
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p /usr/local/etc/moisapps
+mkdir -p /etc/bash_completion.d


### PR DESCRIPTION
Adicionado arquivos para criar pacote deb para instalação do CLI. Fiz somente para Ubuntu com arquitetura amd64.
Para gerar o pacote utilize os comandos:
`go build -o build/package/moisapps/usr/local/bin/moisapps && cd build/package && dpkg-deb --build --root-owner-group moisapps`
Para validar a instalação, pode ser utilizado um container, com o comando:
`podman container run --rm --name ubuntu-jammy -it --entrypoint /bin/bash docker.io/library/ubuntu:jammy`
Para copiar o pacote para o container:
`podman cp build/package/moisapps.deb ubuntu-jammy:/tmp`
Para instalar o pacote:
`dpkg -i /tmp/moisapps.deb`
Para validar a execução do CLI:
`moisapps desenha technology`
![Screenshot from 2022-12-16 19-52-27](https://user-images.githubusercontent.com/10713447/208201734-50829027-c966-4daa-a848-71f440295bb1.png)

closes #14 